### PR TITLE
Fixing Migrate Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "vite build",
     "build:watch": "tsc -w",
     "preview": "vite preview",
-    "migrate": "npx run prisma migrate dev"
+    "migrate": "npx prisma migrate dev"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
The "migrate" script had an unnecessary "run" in the command that caused it to not work correctly.