### PR TITLE
UX Update: Champion Name

### DIFF
--- a/src/client/components/Grid.tsx
+++ b/src/client/components/Grid.tsx
@@ -9,7 +9,7 @@ const Grid = ({ answers }: Props) => {
 	const gridArr = useGridStore((state) => state.grid);
 	const makeGuess = useGridStore((state) => state.makeGuess);
 	return (
-		<div className="grid grid-cols-subgrid grid-flow-row row-start-2 row-span-3 col-span-3 gap-1 px-0">
+		<div className="grid grid-flow-row col-span-3 row-span-3 row-start-2 gap-1 px-0 grid-cols-subgrid">
 			{gridArr.map((ele, ind) => (
 				<Square
 					key={`square${ind}`}

--- a/src/client/components/Square.tsx
+++ b/src/client/components/Square.tsx
@@ -52,9 +52,8 @@ const Square = ({ champion, answer, squareNum, makeGuess }: Props) => {
 		imageObj = champArr[champion.champNum].image;
 		inlineStyle = {
 			backgroundImage: `url(${imageObj.uri})`,
-			backgroundPosition: `${(100 * imageObj.x) / imageObj.width}% ${
-				(100 * imageObj.y) / imageObj.height
-			}%`,
+			backgroundPosition: `${(100 * imageObj.x) / imageObj.width}% ${(100 * imageObj.y) / imageObj.height
+				}%`,
 			backgroundSize: "cover",
 		};
 	}
@@ -66,10 +65,12 @@ const Square = ({ champion, answer, squareNum, makeGuess }: Props) => {
 			disabled={true}
 			variant="outline"
 			size={"lg"}
-			className="size-full bg-cover"
+			className="items-end px-0 bg-cover size-full"
 			style={inlineStyle}
 		>
-			{champion.name}
+			<div className="w-full text-md bg-background size-6">
+				{champion.name}
+			</div>
 		</Button>
 	) : (
 		// guessing dropdown menu if there is not an answer

--- a/src/client/pages/HomePage.tsx
+++ b/src/client/pages/HomePage.tsx
@@ -15,12 +15,12 @@ function HomePage() {
 
 	return (
 		<MaxWidthWrapper>
-			<div className="grid grid-cols-4 grid-rows-5 px-5 grid-flow-row mx-auto aspect-square">
+			<div className="grid grid-flow-row grid-cols-5 grid-rows-5 px-5 mx-auto aspect-square">
 				{rows.map((ele, ind) => (
 					<Button
 						disabled
 						variant={"secondary"}
-						className={` w-1/2 mx-auto my-auto ${rowClass[ind]}`}
+						className={`w-1/2 mx-auto my-auto ${rowClass[ind]}`}
 						key={`row${ind}`}
 					>
 						{ele}
@@ -30,7 +30,7 @@ function HomePage() {
 					<Button
 						disabled
 						variant={"secondary"}
-						className={` w-1/2  mx-auto my-auto ${colClass[ind]}`}
+						className={`w-1/2  mx-auto my-auto ${colClass[ind]}`}
 						key={`col${ind}`}
 					>
 						{ele}
@@ -38,7 +38,7 @@ function HomePage() {
 				))}
 
 				<Grid answers={json.Data} />
-				<div className="my-auto h-full gap-2 flex px-4 justify-center flex-col row-start-5 col-start-2 col-end-5">
+				<div className="flex flex-col justify-center h-full col-start-2 col-end-5 row-start-5 gap-2 px-4 my-auto">
 					<Button disabled variant="secondary">
 						{`Guesses: ${guesses}`}
 					</Button>


### PR DESCRIPTION
Fixes #30
Moved the name to the bottom of the grid square and set the background of the name plate to the background color to have consistent readability