### PR TITLE
hard-coded in logo to work on prod build

### DIFF
--- a/src/client/components/Navbar.tsx
+++ b/src/client/components/Navbar.tsx
@@ -68,7 +68,11 @@ const Navbar = () => {
 						<div className="flex h-16 items-center">
 							<div className="ml-4 flex lg:ml-0">
 								<Link to="/">
-									<img src={"/LOLDoku.png"} alt="logo" className="h-12" />
+									<img
+										src={"/LOLDoku/LOLDoku.png"}
+										alt="logo"
+										className="h-12"
+									/>
 								</Link>
 							</div>
 							<div className="ml-auto flex items-center">


### PR DESCRIPTION
Fix: Hard code in `src` of homepage's logo to redirect to the proper asset location. Should later use proper routing to ensure prod and dev build accurately reflect changes.